### PR TITLE
chore: update bun base image to latest version

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
 # Base image
-FROM oven/bun:1 AS base
+FROM oven/bun:latest AS base
 WORKDIR /usr/src/app
 ENV NODE_ENV=production
 


### PR DESCRIPTION
Update the bun base docker image to the latest version mainly for improved memory consumption in latest versions.